### PR TITLE
Supabase MCP統合を追加

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,15 @@
     "chrome-devtools": {
       "command": "npx",
       "args": ["chrome-devtools-mcp@latest"]
+    },
+    "supabase": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@supabase/mcp-server-supabase@latest",
+        "--access-token",
+        "sbp_d23a3d983ceeda3fd211e142a8a701542d2aec2e"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Supabase MCPサーバーを`.mcp.json`に追加
- Claude CodeからSupabaseのテーブル情報取得やクエリ実行が可能に

## 変更内容
- `.mcp.json`にSupabase MCP設定を追加
  - アクセストークンを含む接続設定
  - `@supabase/mcp-server-supabase`を使用

## Test plan
- [x] Supabase MCPサーバーとの接続確認
- [x] `list_tables`でテーブル一覧取得成功
- [x] 全9テーブルの構造を正常に取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)