### PR TITLE
データベース型定義生成

### DIFF
--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,10 +1,11 @@
 import { createBrowserClient } from '@supabase/ssr'
+import type { Database } from '@/types/database'
 
 /**
  * シングルトンのSupabaseクライアントインスタンス
  * ブラウザ側で1つのクライアントのみを生成・再利用します
  */
-let client: ReturnType<typeof createBrowserClient> | undefined
+let client: ReturnType<typeof createBrowserClient<Database>> | undefined
 
 /**
  * Client Component用のSupabaseクライアントを作成します。
@@ -54,7 +55,7 @@ export function createClient() {
       )
     }
 
-    client = createBrowserClient(supabaseUrl, supabaseAnonKey)
+    client = createBrowserClient<Database>(supabaseUrl, supabaseAnonKey)
   }
 
   return client

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
+import type { Database } from '@/types/database'
 
 /**
  * Server Component用のSupabaseクライアントを作成します。
@@ -45,7 +46,7 @@ export async function createClient() {
 
   const cookieStore = await cookies()
 
-  return createServerClient(supabaseUrl, supabaseAnonKey, {
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll()

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "type-check": "tsc --noEmit",
-    "prepare": "husky"
+    "prepare": "husky",
+    "supabase:gen-types": "supabase gen types typescript --local > types/database.ts"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",

--- a/types/database.ts
+++ b/types/database.ts
@@ -1,0 +1,554 @@
+/**
+ * このファイルはSupabase CLIによって自動生成されています。
+ * 手動で編集しないでください。
+ *
+ * 生成コマンド:
+ * supabase gen types typescript --local > types/database.ts
+ *
+ * または:
+ * npm run supabase:gen-types
+ */
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+  public: {
+    Tables: {
+      line_groups: {
+        Row: {
+          created_at: string
+          group_name: string | null
+          id: string
+          line_group_id: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          group_name?: string | null
+          id?: string
+          line_group_id: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          group_name?: string | null
+          id?: string
+          line_group_id?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      plan_days: {
+        Row: {
+          created_at: string
+          date: string
+          day_number: number
+          end_point: Json | null
+          id: string
+          plan_id: string
+          start_point: Json | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          date: string
+          day_number: number
+          end_point?: Json | null
+          id?: string
+          plan_id: string
+          start_point?: Json | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          date?: string
+          day_number?: number
+          end_point?: Json | null
+          id?: string
+          plan_id?: string
+          start_point?: Json | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "plan_days_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "travel_plans"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      plan_members: {
+        Row: {
+          id: string
+          joined_at: string
+          plan_id: string
+          user_id: string
+        }
+        Insert: {
+          id?: string
+          joined_at?: string
+          plan_id: string
+          user_id: string
+        }
+        Update: {
+          id?: string
+          joined_at?: string
+          plan_id?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "plan_members_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "travel_plans"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "plan_members_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      plan_shares: {
+        Row: {
+          created_at: string
+          expires_at: string | null
+          id: string
+          is_active: boolean
+          plan_id: string
+          share_token: string
+        }
+        Insert: {
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          is_active?: boolean
+          plan_id: string
+          share_token: string
+        }
+        Update: {
+          created_at?: string
+          expires_at?: string | null
+          id?: string
+          is_active?: boolean
+          plan_id?: string
+          share_token?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "plan_shares_plan_id_fkey"
+            columns: ["plan_id"]
+            isOneToOne: false
+            referencedRelation: "travel_plans"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      plan_spots: {
+        Row: {
+          arrival_time: string | null
+          created_at: string
+          custom_location: Json | null
+          custom_name: string | null
+          departure_time: string | null
+          duration_minutes: number | null
+          id: string
+          is_custom: boolean
+          notes: string | null
+          order_index: number
+          plan_day_id: string
+          spot_id: string | null
+          updated_at: string
+        }
+        Insert: {
+          arrival_time?: string | null
+          created_at?: string
+          custom_location?: Json | null
+          custom_name?: string | null
+          departure_time?: string | null
+          duration_minutes?: number | null
+          id?: string
+          is_custom?: boolean
+          notes?: string | null
+          order_index: number
+          plan_day_id: string
+          spot_id?: string | null
+          updated_at?: string
+        }
+        Update: {
+          arrival_time?: string | null
+          created_at?: string
+          custom_location?: Json | null
+          custom_name?: string | null
+          departure_time?: string | null
+          duration_minutes?: number | null
+          id?: string
+          is_custom?: boolean
+          notes?: string | null
+          order_index?: number
+          plan_day_id?: string
+          spot_id?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "plan_spots_plan_day_id_fkey"
+            columns: ["plan_day_id"]
+            isOneToOne: false
+            referencedRelation: "plan_days"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "plan_spots_spot_id_fkey"
+            columns: ["spot_id"]
+            isOneToOne: false
+            referencedRelation: "spots"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      spots: {
+        Row: {
+          address: string | null
+          category: string | null
+          created_at: string
+          google_place_id: string | null
+          id: string
+          latitude: number
+          longitude: number
+          metadata: Json | null
+          name: string
+          photo_url: string | null
+          rating: number | null
+          updated_at: string
+        }
+        Insert: {
+          address?: string | null
+          category?: string | null
+          created_at?: string
+          google_place_id?: string | null
+          id?: string
+          latitude: number
+          longitude: number
+          metadata?: Json | null
+          name: string
+          photo_url?: string | null
+          rating?: number | null
+          updated_at?: string
+        }
+        Update: {
+          address?: string | null
+          category?: string | null
+          created_at?: string
+          google_place_id?: string | null
+          id?: string
+          latitude?: number
+          longitude?: number
+          metadata?: Json | null
+          name?: string
+          photo_url?: string | null
+          rating?: number | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      travel_plans: {
+        Row: {
+          area: string | null
+          created_at: string
+          created_by: string | null
+          display_mode: string
+          end_date: string
+          id: string
+          is_public: boolean
+          line_group_id: string | null
+          start_date: string
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          area?: string | null
+          created_at?: string
+          created_by?: string | null
+          display_mode?: string
+          end_date: string
+          id?: string
+          is_public?: boolean
+          line_group_id?: string | null
+          start_date: string
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          area?: string | null
+          created_at?: string
+          created_by?: string | null
+          display_mode?: string
+          end_date?: string
+          id?: string
+          is_public?: boolean
+          line_group_id?: string | null
+          start_date?: string
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "travel_plans_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      user_settings: {
+        Row: {
+          created_at: string
+          default_display_mode: string
+          id: string
+          notification_enabled: boolean
+          preferences: Json | null
+          reminder_enabled: boolean
+          reminder_hours_before: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          default_display_mode?: string
+          id?: string
+          notification_enabled?: boolean
+          preferences?: Json | null
+          reminder_enabled?: boolean
+          reminder_hours_before?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          default_display_mode?: string
+          id?: string
+          notification_enabled?: boolean
+          preferences?: Json | null
+          reminder_enabled?: boolean
+          reminder_hours_before?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "user_settings_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      users: {
+        Row: {
+          created_at: string
+          display_name: string | null
+          id: string
+          line_user_id: string
+          picture_url: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          display_name?: string | null
+          id?: string
+          line_user_id: string
+          picture_url?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string | null
+          id?: string
+          line_user_id?: string
+          picture_url?: string | null
+          updated_at?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const
+

--- a/types/models.ts
+++ b/types/models.ts
@@ -1,0 +1,155 @@
+/**
+ * データベース型のエイリアス定義
+ *
+ * database.tsから生成された型をより使いやすい形で提供します。
+ * このファイルは手動で編集可能です。
+ */
+
+import type { Database } from './database'
+
+// ========================================
+// Row型（データ取得時）
+// ========================================
+
+/**
+ * ユーザー情報
+ */
+export type User = Database['public']['Tables']['users']['Row']
+
+/**
+ * ユーザー設定
+ */
+export type UserSettings = Database['public']['Tables']['user_settings']['Row']
+
+/**
+ * LINEグループ情報
+ */
+export type LineGroup = Database['public']['Tables']['line_groups']['Row']
+
+/**
+ * 旅行プラン
+ */
+export type TravelPlan = Database['public']['Tables']['travel_plans']['Row']
+
+/**
+ * プランの日程
+ */
+export type PlanDay = Database['public']['Tables']['plan_days']['Row']
+
+/**
+ * プランのスポット
+ */
+export type PlanSpot = Database['public']['Tables']['plan_spots']['Row']
+
+/**
+ * プランのメンバー
+ */
+export type PlanMember = Database['public']['Tables']['plan_members']['Row']
+
+/**
+ * プランの共有設定
+ */
+export type PlanShare = Database['public']['Tables']['plan_shares']['Row']
+
+/**
+ * スポット（マスタデータ）
+ */
+export type Spot = Database['public']['Tables']['spots']['Row']
+
+// ========================================
+// Insert型（新規作成時）
+// ========================================
+
+/**
+ * ユーザー作成時の型
+ */
+export type UserInsert = Database['public']['Tables']['users']['Insert']
+
+/**
+ * ユーザー設定作成時の型
+ */
+export type UserSettingsInsert = Database['public']['Tables']['user_settings']['Insert']
+
+/**
+ * LINEグループ作成時の型
+ */
+export type LineGroupInsert = Database['public']['Tables']['line_groups']['Insert']
+
+/**
+ * 旅行プラン作成時の型
+ */
+export type TravelPlanInsert = Database['public']['Tables']['travel_plans']['Insert']
+
+/**
+ * プラン日程作成時の型
+ */
+export type PlanDayInsert = Database['public']['Tables']['plan_days']['Insert']
+
+/**
+ * プランスポット作成時の型
+ */
+export type PlanSpotInsert = Database['public']['Tables']['plan_spots']['Insert']
+
+/**
+ * プランメンバー作成時の型
+ */
+export type PlanMemberInsert = Database['public']['Tables']['plan_members']['Insert']
+
+/**
+ * プラン共有設定作成時の型
+ */
+export type PlanShareInsert = Database['public']['Tables']['plan_shares']['Insert']
+
+/**
+ * スポット作成時の型
+ */
+export type SpotInsert = Database['public']['Tables']['spots']['Insert']
+
+// ========================================
+// Update型（更新時）
+// ========================================
+
+/**
+ * ユーザー更新時の型
+ */
+export type UserUpdate = Database['public']['Tables']['users']['Update']
+
+/**
+ * ユーザー設定更新時の型
+ */
+export type UserSettingsUpdate = Database['public']['Tables']['user_settings']['Update']
+
+/**
+ * LINEグループ更新時の型
+ */
+export type LineGroupUpdate = Database['public']['Tables']['line_groups']['Update']
+
+/**
+ * 旅行プラン更新時の型
+ */
+export type TravelPlanUpdate = Database['public']['Tables']['travel_plans']['Update']
+
+/**
+ * プラン日程更新時の型
+ */
+export type PlanDayUpdate = Database['public']['Tables']['plan_days']['Update']
+
+/**
+ * プランスポット更新時の型
+ */
+export type PlanSpotUpdate = Database['public']['Tables']['plan_spots']['Update']
+
+/**
+ * プランメンバー更新時の型
+ */
+export type PlanMemberUpdate = Database['public']['Tables']['plan_members']['Update']
+
+/**
+ * プラン共有設定更新時の型
+ */
+export type PlanShareUpdate = Database['public']['Tables']['plan_shares']['Update']
+
+/**
+ * スポット更新時の型
+ */
+export type SpotUpdate = Database['public']['Tables']['spots']['Update']


### PR DESCRIPTION
## 概要

Supabaseデータベースのスキーマから**TypeScript型定義を自動生成**し、型安全なデータベースアクセスを実現しました。

## 実装内容

### 1. 型定義ファイルの生成
- ✅ `types/database.ts` (554行) - Supabase CLIで自動生成
- ✅ `types/models.ts` (155行) - 使いやすい型エイリアス

### 2. 型定義の対象
9つのテーブルすべての型定義（Row/Insert/Update）を含む：
- `users` - ユーザー情報
- `user_settings` - ユーザー設定
- `line_groups` - LINEグループ情報
- `travel_plans` - 旅行プラン
- `plan_days` - プランの日程
- `plan_spots` - プランのスポット
- `plan_members` - プランのメンバー
- `plan_shares` - プランの共有設定
- `spots` - スポット（マスタデータ）

### 3. Supabaseクライアントへの型適用
- ✅ `lib/supabase/server.ts` - Server Component用
- ✅ `lib/supabase/client.ts` - Client Component用

### 4. 開発フローへの組み込み
- ✅ `npm run supabase:gen-types` - 型定義再生成スクリプト

## 効果

- 🎯 **型安全性の確保**: データベースアクセス時のタイポや型ミスをコンパイル時に検出
- 🚀 **開発効率の向上**: エディタでテーブル名・カラム名の補完が効く
- 🔧 **メンテナンス性**: スキーマ変更時にワンコマンドで型定義を更新可能

## テスト計画

- [x] 型チェック成功 (`npm run type-check`)
- [x] Lint通過 (`npm run lint`)
- [x] ビルド成功 (`npm run build`)
- [x] 全テスト合格 (`npm test` - 35テスト)

## 使用例

```typescript
// Server Componentでの使用例
import { createClient } from '@/lib/supabase/server'
import type { TravelPlan } from '@/types/models'

export default async function PlansPage() {
  const supabase = await createClient()
  const { data: plans } = await supabase
    .from('travel_plans')  // ← 補完が効く
    .select('*')
  
  // plansの型はTravelPlan[]として推論される
}
```

## 関連Issue

Closes #20

## フェーズ完了

この実装により、**フェーズ1: データベース構築**がすべて完了しました。
次は**フェーズ2: LINE認証・Bot基盤**（Issue #21〜）に進めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)