### PR TITLE
プラン作成状態管理（Context + LocalStorage）

### DIFF
--- a/__tests__/contexts/plan-form-context.test.tsx
+++ b/__tests__/contexts/plan-form-context.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PlanFormProvider, usePlanForm } from '@/contexts/plan-form-context'
+
+// LocalStorageのモック
+const localStorageMock = (() => {
+  let store: Record<string, string> = {}
+
+  return {
+    getItem: (key: string) => store[key] || null,
+    setItem: (key: string, value: string) => {
+      store[key] = value.toString()
+    },
+    removeItem: (key: string) => {
+      delete store[key]
+    },
+    clear: () => {
+      store = {}
+    },
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+})
+
+// テスト用コンポーネント
+function TestComponent() {
+  const { formData, updateFormData, nextStep, prevStep, resetForm } = usePlanForm()
+
+  return (
+    <div>
+      <div data-testid="current-step">{formData.currentStep}</div>
+      <div data-testid="start-date">{formData.startDate?.toISOString() || 'null'}</div>
+      <div data-testid="end-date">{formData.endDate?.toISOString() || 'null'}</div>
+      <div data-testid="region">{formData.region || 'null'}</div>
+      <div data-testid="prefecture">{formData.prefecture || 'null'}</div>
+
+      <button onClick={nextStep} data-testid="next-step">
+        Next
+      </button>
+      <button onClick={prevStep} data-testid="prev-step">
+        Prev
+      </button>
+      <button onClick={resetForm} data-testid="reset-form">
+        Reset
+      </button>
+      <button
+        onClick={() =>
+          updateFormData({
+            startDate: new Date('2025-10-15'),
+            endDate: new Date('2025-10-17'),
+            region: '関東',
+            prefecture: '東京都',
+          })
+        }
+        data-testid="update-form"
+      >
+        Update
+      </button>
+    </div>
+  )
+}
+
+describe('PlanFormContext', () => {
+  beforeEach(() => {
+    // 各テスト前にLocalStorageをクリア
+    localStorageMock.clear()
+    // コンソールログをモック（ログ出力を抑制）
+    jest.spyOn(console, 'log').mockImplementation()
+    jest.spyOn(console, 'error').mockImplementation()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('基本動作', () => {
+    it('初期値が正しく設定される', () => {
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      expect(screen.getByTestId('current-step')).toHaveTextContent('1')
+      expect(screen.getByTestId('start-date')).toHaveTextContent('null')
+      expect(screen.getByTestId('end-date')).toHaveTextContent('null')
+      expect(screen.getByTestId('region')).toHaveTextContent('null')
+      expect(screen.getByTestId('prefecture')).toHaveTextContent('null')
+    })
+
+    it('usePlanFormがProviderの外で使用された場合にエラーをスローする', () => {
+      // エラーログを抑制
+      const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+      expect(() => {
+        render(<TestComponent />)
+      }).toThrow('usePlanForm must be used within PlanFormProvider')
+
+      consoleError.mockRestore()
+    })
+  })
+
+  describe('フォームデータの更新', () => {
+    it('updateFormDataで部分更新ができる', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      const updateButton = screen.getByTestId('update-form')
+      await user.click(updateButton)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('start-date')).toHaveTextContent('2025-10-15T00:00:00.000Z')
+        expect(screen.getByTestId('end-date')).toHaveTextContent('2025-10-17T00:00:00.000Z')
+        expect(screen.getByTestId('region')).toHaveTextContent('関東')
+        expect(screen.getByTestId('prefecture')).toHaveTextContent('東京都')
+      })
+    })
+  })
+
+  describe('ステップ遷移', () => {
+    it('nextStepでステップが進む', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      const nextButton = screen.getByTestId('next-step')
+
+      expect(screen.getByTestId('current-step')).toHaveTextContent('1')
+
+      await user.click(nextButton)
+      expect(screen.getByTestId('current-step')).toHaveTextContent('2')
+
+      await user.click(nextButton)
+      expect(screen.getByTestId('current-step')).toHaveTextContent('3')
+    })
+
+    it('prevStepでステップが戻る', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      const nextButton = screen.getByTestId('next-step')
+      const prevButton = screen.getByTestId('prev-step')
+
+      // ステップ3まで進む
+      await user.click(nextButton)
+      await user.click(nextButton)
+      expect(screen.getByTestId('current-step')).toHaveTextContent('3')
+
+      // 戻る
+      await user.click(prevButton)
+      expect(screen.getByTestId('current-step')).toHaveTextContent('2')
+    })
+
+    it('ステップは1未満にならない', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      const prevButton = screen.getByTestId('prev-step')
+
+      expect(screen.getByTestId('current-step')).toHaveTextContent('1')
+
+      await user.click(prevButton)
+      expect(screen.getByTestId('current-step')).toHaveTextContent('1')
+    })
+
+    it('ステップは5を超えない', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      const nextButton = screen.getByTestId('next-step')
+
+      // ステップ5まで進む
+      await user.click(nextButton) // 2
+      await user.click(nextButton) // 3
+      await user.click(nextButton) // 4
+      await user.click(nextButton) // 5
+
+      expect(screen.getByTestId('current-step')).toHaveTextContent('5')
+
+      // さらに次へを押しても5のまま
+      await user.click(nextButton)
+      expect(screen.getByTestId('current-step')).toHaveTextContent('5')
+    })
+  })
+
+  describe('フォームリセット', () => {
+    it('resetFormでフォームが初期化される', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      // データを更新
+      const updateButton = screen.getByTestId('update-form')
+      await user.click(updateButton)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('region')).toHaveTextContent('関東')
+      })
+
+      // リセット
+      const resetButton = screen.getByTestId('reset-form')
+      await user.click(resetButton)
+
+      await waitFor(() => {
+        expect(screen.getByTestId('current-step')).toHaveTextContent('1')
+        expect(screen.getByTestId('start-date')).toHaveTextContent('null')
+        expect(screen.getByTestId('end-date')).toHaveTextContent('null')
+        expect(screen.getByTestId('region')).toHaveTextContent('null')
+        expect(screen.getByTestId('prefecture')).toHaveTextContent('null')
+      })
+    })
+  })
+
+  describe('LocalStorage連携', () => {
+    it('フォームデータがLocalStorageに保存される', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      const updateButton = screen.getByTestId('update-form')
+      await user.click(updateButton)
+
+      await waitFor(() => {
+        const saved = localStorageMock.getItem('planFormData')
+        expect(saved).not.toBeNull()
+
+        if (saved) {
+          const parsed = JSON.parse(saved)
+          expect(parsed.region).toBe('関東')
+          expect(parsed.prefecture).toBe('東京都')
+          expect(parsed.startDate).toBe('2025-10-15T00:00:00.000Z')
+        }
+      })
+    })
+
+    it('LocalStorageからデータが復元される', async () => {
+      // 事前にLocalStorageにデータを保存
+      const savedData = {
+        startDate: '2025-10-20T00:00:00.000Z',
+        endDate: '2025-10-22T00:00:00.000Z',
+        region: '関西',
+        prefecture: '京都府',
+        selectedSpots: [],
+        customSpots: [],
+        currentStep: 3,
+        isComplete: false,
+      }
+      localStorageMock.setItem('planFormData', JSON.stringify(savedData))
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('current-step')).toHaveTextContent('3')
+        expect(screen.getByTestId('region')).toHaveTextContent('関西')
+        expect(screen.getByTestId('prefecture')).toHaveTextContent('京都府')
+        expect(screen.getByTestId('start-date')).toHaveTextContent('2025-10-20T00:00:00.000Z')
+      })
+    })
+
+    it('resetFormでLocalStorageがクリアされる', async () => {
+      const user = userEvent.setup()
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      // データを更新（LocalStorageに保存される）
+      const updateButton = screen.getByTestId('update-form')
+      await user.click(updateButton)
+
+      await waitFor(() => {
+        expect(localStorageMock.getItem('planFormData')).not.toBeNull()
+      })
+
+      // リセット
+      const resetButton = screen.getByTestId('reset-form')
+      await user.click(resetButton)
+
+      await waitFor(() => {
+        expect(localStorageMock.getItem('planFormData')).toBeNull()
+      })
+    })
+
+    it('破損したLocalStorageデータがある場合でも正常に動作する', () => {
+      // 不正なJSONを保存
+      localStorageMock.setItem('planFormData', 'invalid json')
+
+      render(
+        <PlanFormProvider>
+          <TestComponent />
+        </PlanFormProvider>
+      )
+
+      // エラーが発生せず、初期値で表示される
+      expect(screen.getByTestId('current-step')).toHaveTextContent('1')
+      expect(screen.getByTestId('region')).toHaveTextContent('null')
+    })
+  })
+})

--- a/app/liff/plan/new/page.tsx
+++ b/app/liff/plan/new/page.tsx
@@ -5,21 +5,40 @@
 
 'use client'
 
-import { useState } from 'react'
 import Link from 'next/link'
+import { PlanFormProvider, usePlanForm } from '@/contexts/plan-form-context'
 
-export default function NewPlanPage() {
-  const [title, setTitle] = useState('')
-  const [startDate, setStartDate] = useState('')
-  const [endDate, setEndDate] = useState('')
+/**
+ * プラン作成フォームコンポーネント（Context内部）
+ */
+function NewPlanForm() {
+  const { formData, updateFormData, nextStep, prevStep, resetForm } = usePlanForm()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
     // TODO: Server Actionでプラン作成
-    console.log('プラン作成:', { title, startDate, endDate })
+    console.log('プラン作成:', {
+      startDate: formData.startDate,
+      endDate: formData.endDate,
+      region: formData.region,
+      prefecture: formData.prefecture,
+    })
 
     alert('プラン作成機能は実装中です')
+  }
+
+  // Date → input[type="date"]用の文字列に変換
+  const formatDateForInput = (date: Date | null): string => {
+    if (!date) return ''
+    return date.toISOString().split('T')[0]
+  }
+
+  // input[type="date"]の文字列 → Dateに変換
+  const handleDateChange = (field: 'startDate' | 'endDate', value: string) => {
+    updateFormData({
+      [field]: value ? new Date(value) : null,
+    })
   }
 
   return (
@@ -33,27 +52,14 @@ export default function NewPlanPage() {
           <p className="text-sm text-gray-600">
             旅行プランの基本情報を入力してください
           </p>
+          {/* デバッグ情報 */}
+          <p className="text-xs text-gray-400 mt-2">
+            現在のステップ: {formData.currentStep} / 5
+          </p>
         </div>
 
         {/* フォーム */}
         <form onSubmit={handleSubmit} className="space-y-6">
-          {/* プラン名 */}
-          <div className="bg-white rounded-lg shadow p-6">
-            <label className="block mb-2">
-              <span className="text-sm font-semibold text-gray-700">
-                プラン名 <span className="text-red-500">*</span>
-              </span>
-              <input
-                type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
-                placeholder="例: 京都旅行 2025春"
-                required
-                className="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-            </label>
-          </div>
-
           {/* 日程 */}
           <div className="bg-white rounded-lg shadow p-6 space-y-4">
             <h3 className="text-sm font-semibold text-gray-700 mb-3">
@@ -64,8 +70,8 @@ export default function NewPlanPage() {
               <span className="text-sm text-gray-600">出発日</span>
               <input
                 type="date"
-                value={startDate}
-                onChange={(e) => setStartDate(e.target.value)}
+                value={formatDateForInput(formData.startDate)}
+                onChange={(e) => handleDateChange('startDate', e.target.value)}
                 required
                 className="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
@@ -75,12 +81,42 @@ export default function NewPlanPage() {
               <span className="text-sm text-gray-600">帰着日</span>
               <input
                 type="date"
-                value={endDate}
-                onChange={(e) => setEndDate(e.target.value)}
+                value={formatDateForInput(formData.endDate)}
+                onChange={(e) => handleDateChange('endDate', e.target.value)}
                 required
                 className="mt-1 block w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </label>
+          </div>
+
+          {/* デバッグ用ステップ操作ボタン */}
+          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+            <p className="text-xs font-semibold text-yellow-800 mb-2">
+              デバッグ用コントロール
+            </p>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={prevStep}
+                className="px-3 py-1 text-sm bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+              >
+                ← 前のステップ
+              </button>
+              <button
+                type="button"
+                onClick={nextStep}
+                className="px-3 py-1 text-sm bg-blue-200 text-blue-700 rounded hover:bg-blue-300"
+              >
+                次のステップ →
+              </button>
+              <button
+                type="button"
+                onClick={resetForm}
+                className="px-3 py-1 text-sm bg-red-200 text-red-700 rounded hover:bg-red-300"
+              >
+                リセット
+              </button>
+            </div>
           </div>
 
           {/* アクションボタン */}
@@ -89,7 +125,7 @@ export default function NewPlanPage() {
               type="submit"
               className="w-full px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-semibold"
             >
-              プランを作成
+              プランを作成（開発中）
             </button>
 
             <Link
@@ -112,5 +148,16 @@ export default function NewPlanPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+/**
+ * プラン作成ページ（Context Provider付き）
+ */
+export default function NewPlanPage() {
+  return (
+    <PlanFormProvider>
+      <NewPlanForm />
+    </PlanFormProvider>
   )
 }

--- a/contexts/plan-form-context.tsx
+++ b/contexts/plan-form-context.tsx
@@ -1,0 +1,239 @@
+'use client'
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react'
+import type { PlanFormData } from '@/types/models'
+
+/**
+ * プランフォームContextの型定義
+ */
+interface PlanFormContextType {
+  /** フォームデータ */
+  formData: PlanFormData
+  /** フォームデータを部分更新する関数 */
+  updateFormData: (data: Partial<PlanFormData>) => void
+  /** 次のステップに進む関数 */
+  nextStep: () => void
+  /** 前のステップに戻る関数 */
+  prevStep: () => void
+  /** フォームをリセットする関数 */
+  resetForm: () => void
+}
+
+/**
+ * プランフォームContext
+ */
+const PlanFormContext = createContext<PlanFormContextType | undefined>(undefined)
+
+/**
+ * プランフォームプロバイダーのProps
+ */
+interface PlanFormProviderProps {
+  children: ReactNode
+}
+
+/**
+ * LocalStorageのキー定義
+ */
+const STORAGE_KEY = 'planFormData'
+
+/**
+ * 初期フォームデータ
+ */
+const initialFormData: PlanFormData = {
+  startDate: null,
+  endDate: null,
+  region: null,
+  prefecture: null,
+  selectedSpots: [],
+  customSpots: [],
+  currentStep: 1,
+  isComplete: false,
+}
+
+/**
+ * LocalStorageに保存する際のデータ型
+ * Date型は文字列として保存される
+ */
+interface StoredPlanFormData extends Omit<PlanFormData, 'startDate' | 'endDate'> {
+  startDate: string | null
+  endDate: string | null
+}
+
+/**
+ * プランフォームプロバイダー
+ * プラン作成フローの状態を管理し、LocalStorageに自動保存する
+ *
+ * @example
+ * ```tsx
+ * <PlanFormProvider>
+ *   <PlanCreationSteps />
+ * </PlanFormProvider>
+ * ```
+ */
+export function PlanFormProvider({ children }: PlanFormProviderProps) {
+  const [formData, setFormData] = useState<PlanFormData>(initialFormData)
+  const [isHydrated, setIsHydrated] = useState(false)
+
+  /**
+   * 初回マウント時にLocalStorageからデータを復元
+   */
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (saved) {
+        const parsed: StoredPlanFormData = JSON.parse(saved)
+
+        // Date型の復元（ISO文字列 → Dateオブジェクト）
+        const restored: PlanFormData = {
+          ...parsed,
+          startDate: parsed.startDate ? new Date(parsed.startDate) : null,
+          endDate: parsed.endDate ? new Date(parsed.endDate) : null,
+        }
+
+        setFormData(restored)
+        console.log('[PlanFormContext] Restored from localStorage:', {
+          currentStep: restored.currentStep,
+          hasStartDate: !!restored.startDate,
+          hasEndDate: !!restored.endDate,
+        })
+      }
+    } catch (error) {
+      console.error('[PlanFormContext] Failed to restore from localStorage:', error)
+      // 復元失敗時は初期値を使用
+    } finally {
+      setIsHydrated(true)
+    }
+  }, [])
+
+  /**
+   * フォームデータが変更されたらLocalStorageに保存
+   * 初回のハイドレーション時はスキップ
+   * 初期値と完全一致する場合もスキップ（リセット後の不要な保存を防ぐ）
+   */
+  useEffect(() => {
+    if (!isHydrated) return
+
+    // 初期値と完全一致する場合はLocalStorageから削除
+    if (JSON.stringify(formData) === JSON.stringify(initialFormData)) {
+      try {
+        localStorage.removeItem(STORAGE_KEY)
+        console.log('[PlanFormContext] Removed from localStorage (initial state)')
+      } catch (error) {
+        console.error('[PlanFormContext] Failed to remove from localStorage:', error)
+      }
+      return
+    }
+
+    try {
+      // Date型の変換（Dateオブジェクト → ISO文字列）
+      const toStore: StoredPlanFormData = {
+        ...formData,
+        startDate: formData.startDate ? formData.startDate.toISOString() : null,
+        endDate: formData.endDate ? formData.endDate.toISOString() : null,
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore))
+      console.log('[PlanFormContext] Saved to localStorage')
+    } catch (error) {
+      console.error('[PlanFormContext] Failed to save to localStorage:', error)
+      // 保存失敗時もユーザー体験を損なわないため、エラーは握りつぶす
+    }
+  }, [formData, isHydrated])
+
+  /**
+   * フォームデータを部分更新
+   */
+  const updateFormData = (data: Partial<PlanFormData>) => {
+    setFormData((prev) => ({ ...prev, ...data }))
+  }
+
+  /**
+   * 次のステップに進む
+   * 最大ステップ数は5
+   */
+  const nextStep = () => {
+    setFormData((prev) => ({
+      ...prev,
+      currentStep: Math.min(prev.currentStep + 1, 5),
+    }))
+  }
+
+  /**
+   * 前のステップに戻る
+   * 最小ステップ数は1
+   */
+  const prevStep = () => {
+    setFormData((prev) => ({
+      ...prev,
+      currentStep: Math.max(prev.currentStep - 1, 1),
+    }))
+  }
+
+  /**
+   * フォームをリセット
+   * LocalStorageからもデータを削除
+   */
+  const resetForm = () => {
+    setFormData(initialFormData)
+    // useEffectで初期値と判定され、自動的にLocalStorageから削除される
+  }
+
+  // Context値をメモ化して不要な再レンダリングを防ぐ
+  const value: PlanFormContextType = useMemo(
+    () => ({
+      formData,
+      updateFormData,
+      nextStep,
+      prevStep,
+      resetForm,
+    }),
+    [formData]
+  )
+
+  return <PlanFormContext.Provider value={value}>{children}</PlanFormContext.Provider>
+}
+
+/**
+ * プランフォームContextを使用するためのカスタムフック
+ *
+ * @throws PlanFormProviderの外で使用された場合にエラー
+ * @returns プランフォームの状態と操作関数
+ *
+ * @example
+ * ```tsx
+ * function Step1() {
+ *   const { formData, updateFormData, nextStep } = usePlanForm()
+ *
+ *   const handleDateChange = (startDate: Date, endDate: Date) => {
+ *     updateFormData({ startDate, endDate })
+ *     nextStep()
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       <DatePicker
+ *         startDate={formData.startDate}
+ *         endDate={formData.endDate}
+ *         onChange={handleDateChange}
+ *       />
+ *     </div>
+ *   )
+ * }
+ * ```
+ */
+export function usePlanForm() {
+  const context = useContext(PlanFormContext)
+
+  if (context === undefined) {
+    throw new Error('usePlanForm must be used within PlanFormProvider')
+  }
+
+  return context
+}

--- a/hooks/use-plan-form-storage.ts
+++ b/hooks/use-plan-form-storage.ts
@@ -1,0 +1,83 @@
+import { useEffect } from 'react'
+
+/**
+ * LocalStorageのキー定義
+ */
+const STORAGE_KEY = 'planFormData'
+
+/**
+ * プランフォームデータをLocalStorageに保存・復元するフック
+ *
+ * @template T - 保存するデータの型
+ * @param data - 保存するデータ
+ * @param enabled - LocalStorageへの保存を有効にするか（デフォルト: true）
+ * @returns LocalStorage操作関数
+ *
+ * @example
+ * ```tsx
+ * const { restore, clear } = usePlanFormStorage(formData)
+ *
+ * // 復元
+ * const savedData = restore()
+ *
+ * // クリア
+ * clear()
+ * ```
+ */
+export function usePlanFormStorage<T>(data: T, enabled = true) {
+  /**
+   * データをLocalStorageに保存
+   * useEffectで自動的に実行される
+   */
+  useEffect(() => {
+    if (!enabled) return
+
+    try {
+      const serialized = JSON.stringify(data)
+      localStorage.setItem(STORAGE_KEY, serialized)
+      console.log('[usePlanFormStorage] Data saved to localStorage')
+    } catch (error) {
+      console.error('[usePlanFormStorage] Failed to save to localStorage:', error)
+      // QuotaExceededError（容量超過）やその他のエラーをキャッチ
+      // ユーザー体験を損なわないため、エラーは握りつぶす
+    }
+  }, [data, enabled])
+
+  /**
+   * LocalStorageからデータを復元
+   *
+   * @returns 復元されたデータ、または復元失敗時はnull
+   */
+  function restore(): T | null {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY)
+      if (!saved) {
+        console.log('[usePlanFormStorage] No saved data found')
+        return null
+      }
+
+      const parsed = JSON.parse(saved) as T
+      console.log('[usePlanFormStorage] Data restored from localStorage')
+      return parsed
+    } catch (error) {
+      console.error('[usePlanFormStorage] Failed to restore from localStorage:', error)
+      // パースエラーなどをキャッチ
+      // 破損したデータは無視してnullを返す
+      return null
+    }
+  }
+
+  /**
+   * LocalStorageからデータを削除
+   */
+  function clear() {
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+      console.log('[usePlanFormStorage] Data cleared from localStorage')
+    } catch (error) {
+      console.error('[usePlanFormStorage] Failed to clear localStorage:', error)
+    }
+  }
+
+  return { restore, clear }
+}

--- a/types/models.ts
+++ b/types/models.ts
@@ -153,3 +153,53 @@ export type PlanShareUpdate = Database['public']['Tables']['plan_shares']['Updat
  * スポット更新時の型
  */
 export type SpotUpdate = Database['public']['Tables']['spots']['Update']
+
+// ========================================
+// プラン作成フロー用の型定義
+// ========================================
+
+/**
+ * カスタムスポット（ユーザーが手動で追加するスポット）
+ */
+export interface CustomSpot {
+  /** スポット名 */
+  name: string
+  /** 緯度 */
+  lat: number
+  /** 経度 */
+  lng: number
+  /** 住所（オプション） */
+  address?: string
+  /** カテゴリ（オプション） */
+  category?: string
+}
+
+/**
+ * プラン作成フォームのデータ
+ * Context + LocalStorageで管理される状態
+ */
+export interface PlanFormData {
+  // ステップ1: 日程
+  /** 開始日 */
+  startDate: Date | null
+  /** 終了日 */
+  endDate: Date | null
+
+  // ステップ2: エリア
+  /** 地方（例: 関東） */
+  region: string | null
+  /** 都道府県（例: 東京都） */
+  prefecture: string | null
+
+  // ステップ3: スポット
+  /** 選択されたスポット（マスタから） */
+  selectedSpots: Spot[]
+  /** カスタムスポット（手動追加） */
+  customSpots: CustomSpot[]
+
+  // メタ情報
+  /** 現在のステップ（1-5） */
+  currentStep: number
+  /** プラン作成完了フラグ */
+  isComplete: boolean
+}


### PR DESCRIPTION
## Summary

GitHub issue#28の実装: プラン作成フローの状態管理システムを構築しました。

### 実装内容

#### 1. 型定義の追加 (`types/models.ts`)
- `CustomSpot`: ユーザーが手動で追加するスポットの型
- `PlanFormData`: Context + LocalStorageで管理される状態の型
  - 日程（startDate, endDate）
  - エリア（region, prefecture）
  - スポット（selectedSpots, customSpots）
  - メタ情報（currentStep, isComplete）

#### 2. LocalStorage保存フック (`hooks/use-plan-form-storage.ts`)
- フォームデータをLocalStorageに保存・復元
- エラーハンドリング付きの安全な実装
- 将来の拡張性を考慮した設計

#### 3. プラン作成フォーム用Context (`contexts/plan-form-context.tsx`)
- `PlanFormProvider`: 状態管理プロバイダー
- `usePlanForm`: カスタムフック
- LocalStorageとの自動連携（保存・復元）
- Date型のISO文字列変換処理
- ステップ遷移機能:
  - `nextStep()`: 次のステップへ（最大5）
  - `prevStep()`: 前のステップへ（最小1）
  - `resetForm()`: フォームリセット + LocalStorageクリア
  - `updateFormData()`: 部分的な状態更新

#### 4. プラン作成ページへの適用 (`app/liff/plan/new/page.tsx`)
- `PlanFormProvider`でラップ
- `usePlanForm()`経由でデータ取得・更新
- デバッグ用ステップ操作UI追加（Issue#29で削除予定）

#### 5. テスト (`__tests__/contexts/plan-form-context.test.tsx`)
- 12個のテストケースで包括的にカバー
- LocalStorageモックによる隔離されたテスト環境
- 全テストがパス済み

### 技術的なポイント

#### Context + LocalStorageパターン
- **Context API**: コンポーネント間のデータ共有（props drilling回避）
- **LocalStorage**: ページリロード耐性（UX向上）
- **ハイドレーション制御**: 初回復元と保存を適切に分離
- **Date型の変換**: JSON保存時はISO文字列、復元時にDateオブジェクトに変換

#### LocalStorageの自動管理
```typescript
// 初期値と一致する場合は自動的にLocalStorageから削除
if (JSON.stringify(formData) === JSON.stringify(initialFormData)) {
  localStorage.removeItem(STORAGE_KEY)
  return
}
```

### 動作確認

#### 基本動作
1. 日程を入力 → LocalStorageに自動保存
2. ページリロード → 入力内容が復元される
3. リセットボタン → LocalStorageがクリアされる

#### 確認方法
```bash
npm run dev:liff
# ブラウザでngrok URLを開く
# F12 > Application > Local Storage で確認
```

## Test plan

- [x] 型チェック: `npm run type-check` ✅
- [x] Lint: `npm run lint` ✅（警告は既存ファイルのみ）
- [x] テスト: `npm run test` ✅（12/12テストパス）
- [x] ビルド: `npm run build` ✅

### テストカバレッジ
- 基本動作（初期値、エラーハンドリング）
- フォームデータ更新
- ステップ遷移（上下限チェック含む）
- LocalStorage連携（保存/復元/クリア）
- 破損データのエラーハンドリング

## 注意事項

### デバッグUIについて
現在のプラン作成ページには、動作確認用のデバッグUI（黄色いエリア）があります:
- 現在のステップ表示
- ステップ操作ボタン（前へ/次へ/リセット）

**これらはIssue#29（ステップ式UI実装）で削除される予定です。**

### 今後の実装
- Issue#29: 本格的なステップ式UIコンポーネント
  - ステップインジケーター
  - 各ステップの詳細UI（カレンダー、エリア選択、スポット選択等）
- Issue#30以降: Google Maps連携、スポット検索機能等

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)