### PR TITLE
スポット保存Server Action実装 (issue#41)

### DIFF
--- a/__tests__/actions/spots.test.ts
+++ b/__tests__/actions/spots.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Server Actions (spots.ts) のテスト
+ *
+ * 注意: このテストは最小限のモックでSupabaseクライアントをモック化します
+ */
+
+import { saveSpot } from '@/actions/spots'
+import type { PlaceResult } from '@/lib/maps/places'
+import type { Tables } from '@/types/database'
+
+// Supabaseクライアントをモック
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() => ({
+    from: mockFrom,
+  })),
+}))
+
+describe('Server Actions: spots.ts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('saveSpot', () => {
+    it('新規スポットを保存できる', async () => {
+      // Arrange: テストデータを準備
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJN1t_tDeuEmsRUsoyG83frY4',
+        name: '東京タワー',
+        address: '東京都港区芝公園4-2-8',
+        lat: 35.6585805,
+        lng: 139.7454329,
+        photoUrl: 'https://example.com/photo.jpg',
+        rating: 4.5,
+        types: ['tourist_attraction', 'point_of_interest'],
+      }
+
+      const mockSavedSpot: Tables<'spots'> = {
+        id: 'spot-id-123',
+        google_place_id: placeResult.placeId,
+        name: placeResult.name,
+        address: placeResult.address,
+        latitude: placeResult.lat,
+        longitude: placeResult.lng,
+        photo_url: placeResult.photoUrl ?? null,
+        rating: placeResult.rating ?? null,
+        category: 'tourist_attraction',
+        metadata: { types: placeResult.types },
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      }
+
+      // 既存スポット検索: 見つからない
+      mockFrom.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // 新規スポット作成
+      mockFrom.mockReturnValueOnce({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: mockSavedSpot,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // Act: 関数を実行
+      const result = await saveSpot(placeResult)
+
+      // Assert: 結果を検証
+      expect(result.error).toBeNull()
+      expect(result.data).not.toBeNull()
+      expect(result.data?.google_place_id).toBe(placeResult.placeId)
+      expect(result.data?.name).toBe(placeResult.name)
+      expect(result.data?.latitude).toBe(placeResult.lat)
+      expect(result.data?.longitude).toBe(placeResult.lng)
+      expect(result.data?.category).toBe('tourist_attraction')
+    })
+
+    it('既存スポット（重複）の場合は既存レコードを返す', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJN1t_tDeuEmsRUsoyG83frY4',
+        name: '東京タワー',
+        address: '東京都港区芝公園4-2-8',
+        lat: 35.6585805,
+        lng: 139.7454329,
+      }
+
+      const existingSpot: Tables<'spots'> = {
+        id: 'existing-spot-id',
+        google_place_id: placeResult.placeId,
+        name: placeResult.name,
+        address: placeResult.address,
+        latitude: placeResult.lat,
+        longitude: placeResult.lng,
+        photo_url: null,
+        rating: null,
+        category: null,
+        metadata: null,
+        created_at: '2024-12-01T00:00:00Z',
+        updated_at: '2024-12-01T00:00:00Z',
+      }
+
+      // 既存スポット検索: 見つかる
+      mockFrom.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: existingSpot,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBeNull()
+      expect(result.data).not.toBeNull()
+      expect(result.data?.id).toBe('existing-spot-id')
+      expect(result.data?.google_place_id).toBe(placeResult.placeId)
+      // insertは呼ばれない（重複チェックで既存レコードを返すだけ）
+      expect(mockFrom).toHaveBeenCalledTimes(1) // selectのみ
+    })
+
+    it('photoUrlがない場合でも保存できる', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test',
+        name: 'テストスポット',
+        address: 'テスト住所',
+        lat: 35.0,
+        lng: 139.0,
+        // photoUrlなし
+      }
+
+      const mockSavedSpot: Tables<'spots'> = {
+        id: 'spot-id-456',
+        google_place_id: placeResult.placeId,
+        name: placeResult.name,
+        address: placeResult.address,
+        latitude: placeResult.lat,
+        longitude: placeResult.lng,
+        photo_url: null,
+        rating: null,
+        category: null,
+        metadata: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      }
+
+      // 既存スポット検索: 見つからない
+      mockFrom.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // 新規スポット作成
+      mockFrom.mockReturnValueOnce({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: mockSavedSpot,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBeNull()
+      expect(result.data?.photo_url).toBeNull()
+    })
+
+    it('ratingがない場合でも保存できる', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test2',
+        name: 'テストスポット2',
+        address: 'テスト住所2',
+        lat: 35.0,
+        lng: 139.0,
+        // ratingなし
+      }
+
+      const mockSavedSpot: Tables<'spots'> = {
+        id: 'spot-id-789',
+        google_place_id: placeResult.placeId,
+        name: placeResult.name,
+        address: placeResult.address,
+        latitude: placeResult.lat,
+        longitude: placeResult.lng,
+        photo_url: null,
+        rating: null,
+        category: null,
+        metadata: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      }
+
+      // 既存スポット検索: 見つからない
+      mockFrom.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // 新規スポット作成
+      mockFrom.mockReturnValueOnce({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: mockSavedSpot,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBeNull()
+      expect(result.data?.rating).toBeNull()
+    })
+
+    it('typesがある場合はcategoryとmetadataに保存される', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test3',
+        name: '美術館',
+        address: 'テスト住所3',
+        lat: 35.0,
+        lng: 139.0,
+        types: ['museum', 'tourist_attraction', 'point_of_interest'],
+      }
+
+      const mockSavedSpot: Tables<'spots'> = {
+        id: 'spot-id-abc',
+        google_place_id: placeResult.placeId,
+        name: placeResult.name,
+        address: placeResult.address,
+        latitude: placeResult.lat,
+        longitude: placeResult.lng,
+        photo_url: null,
+        rating: null,
+        category: 'museum', // 最初のtypeがcategoryに
+        metadata: { types: placeResult.types }, // 全てのtypesをmetadataに
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      }
+
+      // 既存スポット検索: 見つからない
+      mockFrom.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // 新規スポット作成
+      mockFrom.mockReturnValueOnce({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: mockSavedSpot,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBeNull()
+      expect(result.data?.category).toBe('museum')
+      expect(result.data?.metadata).toEqual({ types: placeResult.types })
+    })
+
+    it('typesがない場合でも保存できる', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test4',
+        name: 'typesなしスポット',
+        address: 'テスト住所4',
+        lat: 35.0,
+        lng: 139.0,
+        // typesなし
+      }
+
+      const mockSavedSpot: Tables<'spots'> = {
+        id: 'spot-id-def',
+        google_place_id: placeResult.placeId,
+        name: placeResult.name,
+        address: placeResult.address,
+        latitude: placeResult.lat,
+        longitude: placeResult.lng,
+        photo_url: null,
+        rating: null,
+        category: null, // typesがないのでcategoryもnull
+        metadata: null,
+        created_at: '2025-01-01T00:00:00Z',
+        updated_at: '2025-01-01T00:00:00Z',
+      }
+
+      // 既存スポット検索: 見つからない
+      mockFrom.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // 新規スポット作成
+      mockFrom.mockReturnValueOnce({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: mockSavedSpot,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBeNull()
+      expect(result.data?.category).toBeNull()
+      expect(result.data?.metadata).toBeNull()
+    })
+
+    it('空のplaceIdの場合はエラーを返す', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: '',
+        name: 'テストスポット',
+        address: 'テスト住所',
+        lat: 35.0,
+        lng: 139.0,
+      }
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBe('Google Place IDが無効です')
+      expect(result.data).toBeNull()
+    })
+
+    it('空のnameの場合はエラーを返す', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test5',
+        name: '',
+        address: 'テスト住所',
+        lat: 35.0,
+        lng: 139.0,
+      }
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBe('スポット名が無効です')
+      expect(result.data).toBeNull()
+    })
+
+    it('緯度が範囲外の場合はエラーを返す', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test6',
+        name: 'テストスポット',
+        address: 'テスト住所',
+        lat: 91.0, // 範囲外（-90〜90）
+        lng: 139.0,
+      }
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBe('緯度・経度の値が無効です')
+      expect(result.data).toBeNull()
+    })
+
+    it('経度が範囲外の場合はエラーを返す', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test7',
+        name: 'テストスポット',
+        address: 'テスト住所',
+        lat: 35.0,
+        lng: 181.0, // 範囲外（-180〜180）
+      }
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).toBe('緯度・経度の値が無効です')
+      expect(result.data).toBeNull()
+    })
+
+    it('データベースエラー時は適切にエラーハンドリングされる', async () => {
+      // Arrange
+      const placeResult: PlaceResult = {
+        placeId: 'ChIJ_test8',
+        name: 'エラーテスト',
+        address: 'テスト住所',
+        lat: 35.0,
+        lng: 139.0,
+      }
+
+      // 既存スポット検索: 見つからない
+      mockFrom.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            maybeSingle: jest.fn().mockResolvedValue({
+              data: null,
+              error: null,
+            }),
+          }),
+        }),
+      })
+
+      // 新規スポット作成: エラー発生
+      mockFrom.mockReturnValueOnce({
+        insert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: null,
+              error: { message: 'Database connection error' },
+            }),
+          }),
+        }),
+      })
+
+      // Act
+      const result = await saveSpot(placeResult)
+
+      // Assert
+      expect(result.error).not.toBeNull()
+      expect(result.data).toBeNull()
+    })
+  })
+})

--- a/actions/spots.ts
+++ b/actions/spots.ts
@@ -1,0 +1,118 @@
+'use server'
+
+import { createClient } from '@/lib/supabase/server'
+import type { PlaceResult } from '@/lib/maps/places'
+import type { Tables } from '@/types/database'
+
+/**
+ * スポット保存結果
+ */
+interface SaveSpotResult {
+  data: Tables<'spots'> | null
+  error: string | null
+}
+
+/**
+ * PlaceResultをSupabaseのspotsテーブルに保存する
+ *
+ * @param spot - Places APIから取得したスポット情報
+ * @returns 保存されたスポットレコード、またはエラー
+ *
+ * @remarks
+ * - google_place_idで重複チェックを行う
+ * - 既存レコードがあれば、新規作成せずに既存レコードを返す
+ * - Places APIのtypesは最初の要素をcategoryに保存
+ * - その他のメタデータはmetadataフィールドにJSON形式で保存
+ * - APIコスト削減のため、同じスポットは複数回保存しない
+ *
+ * @example
+ * ```typescript
+ * const placeResult = await searchPlacesByArea('東京都')
+ * const result = await saveSpot(placeResult[0])
+ *
+ * if (result.error) {
+ *   console.error('保存失敗:', result.error)
+ * } else {
+ *   console.log('保存成功:', result.data.id)
+ * }
+ * ```
+ */
+export async function saveSpot(spot: PlaceResult): Promise<SaveSpotResult> {
+  try {
+    // 1. 入力値の検証
+    if (!spot.placeId || spot.placeId.trim() === '') {
+      console.error('[saveSpot] Invalid placeId:', spot.placeId)
+      return {
+        data: null,
+        error: 'Google Place IDが無効です',
+      }
+    }
+
+    if (!spot.name || spot.name.trim() === '') {
+      console.error('[saveSpot] Invalid name:', spot.name)
+      return {
+        data: null,
+        error: 'スポット名が無効です',
+      }
+    }
+
+    // 緯度・経度の範囲チェック（-90〜90、-180〜180）
+    if (spot.lat < -90 || spot.lat > 90 || spot.lng < -180 || spot.lng > 180) {
+      console.error('[saveSpot] Invalid coordinates:', { lat: spot.lat, lng: spot.lng })
+      return {
+        data: null,
+        error: '緯度・経度の値が無効です',
+      }
+    }
+
+    const supabase = await createClient()
+
+    // 2. Google Place IDで重複チェック
+    const { data: existingSpot, error: selectError } = await supabase
+      .from('spots')
+      .select('*')
+      .eq('google_place_id', spot.placeId)
+      .maybeSingle()
+
+    // 既存レコードがあれば返す
+    if (existingSpot) {
+      console.log(`[saveSpot] Spot already exists: ${spot.name} (ID: ${existingSpot.id})`)
+      return { data: existingSpot, error: null }
+    }
+
+    // selectErrorがある場合（レコードが見つからない以外のエラー）
+    if (selectError) {
+      console.error('[saveSpot] Select error:', selectError)
+      return { data: null, error: selectError.message }
+    }
+
+    // 3. 新規作成
+    const { data, error: insertError } = await supabase
+      .from('spots')
+      .insert({
+        google_place_id: spot.placeId,
+        name: spot.name,
+        address: spot.address,
+        latitude: spot.lat,
+        longitude: spot.lng,
+        photo_url: spot.photoUrl,
+        rating: spot.rating,
+        category: spot.types?.[0], // 最初のtypeをcategoryとして保存
+        metadata: spot.types ? { types: spot.types } : null, // typesを全てmetadataに保存
+      })
+      .select()
+      .single()
+
+    if (insertError) {
+      console.error('[saveSpot] Insert error:', insertError)
+      return { data: null, error: insertError.message }
+    }
+
+    console.log(`[saveSpot] Successfully saved spot: ${spot.name} (ID: ${data.id})`)
+    return { data, error: null }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'スポットの保存に失敗しました'
+    console.error('[saveSpot] Unexpected error:', error)
+    return { data: null, error: message }
+  }
+}


### PR DESCRIPTION
## 📋 概要

Places APIから取得したスポット情報をSupabaseのspotsテーブルに保存する`saveSpot` Server Actionを実装しました。

## ✨ 実装内容

### 1. Server Action実装 (`actions/spots.ts`)

- **重複チェック**: Google Place IDで既存レコードを検索
- **入力値検証**: placeId、name、座標範囲を厳密にチェック
- **データ変換**: Places APIの`types`配列を`category`（単一値）と`metadata`（JSON）に変換
- **エラーハンドリング**: 詳細なログ出力と適切なエラーメッセージ

### 2. テストスイート (`__tests__/actions/spots.test.ts`)

- **正常系テスト**: 新規保存、重複検出、オプショナルフィールド対応
- **異常系テスト**: 入力値検証、座標範囲、DBエラー
- **11個のテスト全てpass**

## 🧪 テスト計画

- ✅ ユニットテスト（11件）: 全てpass
- ✅ 型チェック: pass
- ✅ リント: pass（既存の警告のみ）
- ✅ ビルド: 成功

## 🔧 開発手法

**TDD（Test-Driven Development）**に従って実装:
1. **Red**: テストを先に作成し、失敗を確認
2. **Green**: 最小限の実装でテストをpass
3. **Refactor**: 型チェック・リントで品質確保

## 🔗 関連Issue

Closes #41

## 📝 備考

- UI側の統合は次のissue（フェーズ5: 旅程自動生成・保存）で実装予定
- 現時点では画面操作でのDB保存は未実装
- Server Action単体の動作確認はテストコードで完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)