### PR TITLE
Directions API ラッパー実装 (issue#43)

### DIFF
--- a/__tests__/lib/maps/directions.test.ts
+++ b/__tests__/lib/maps/directions.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Directions APIラッパーのテスト
+ */
+
+import {
+  getDirections,
+  getMultipleRoutes,
+  calculateTotalDuration,
+  formatDuration,
+} from '@/lib/maps/directions'
+import { initGoogleMaps } from '@/lib/maps/loader'
+
+// Google Maps APIをモック
+jest.mock('@/lib/maps/loader')
+
+describe('Directions API Wrapper', () => {
+  let mockService: {
+    route: jest.Mock
+  }
+
+  beforeEach(() => {
+    // DirectionsServiceのモックを作成
+    mockService = {
+      route: jest.fn(),
+    }
+
+    // initGoogleMapsのモック
+    ;(initGoogleMaps as jest.Mock).mockResolvedValue({
+      maps: {
+        DirectionsService: jest.fn(() => mockService),
+        DirectionsStatus: {
+          OK: 'OK',
+          NOT_FOUND: 'NOT_FOUND',
+          ZERO_RESULTS: 'ZERO_RESULTS',
+          ERROR: 'ERROR',
+        },
+        TravelMode: {
+          WALKING: 'WALKING',
+          DRIVING: 'DRIVING',
+          TRANSIT: 'TRANSIT',
+          BICYCLING: 'BICYCLING',
+        },
+        LatLng: jest.fn((lat, lng) => ({ lat, lng })),
+      },
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getDirections', () => {
+    it('2地点間のルート情報を取得できる', async () => {
+      const mockResult = {
+        routes: [
+          {
+            legs: [
+              {
+                distance: { value: 1200 },
+                duration: { value: 900 },
+                start_address: '東京都港区芝公園4-2-8',
+                end_address: '東京都港区芝公園3-4-1',
+              },
+            ],
+            overview_polyline: 'encodedPolylineString',
+          },
+        ],
+      }
+
+      mockService.route.mockImplementation((request, callback) => {
+        callback(mockResult, 'OK')
+      })
+
+      const result = await getDirections(
+        { lat: 35.6586, lng: 139.7454 },
+        { lat: 35.6585, lng: 139.7471 }
+      )
+
+      expect(result).toEqual({
+        distance: 1200,
+        duration: 900,
+        startAddress: '東京都港区芝公園4-2-8',
+        endAddress: '東京都港区芝公園3-4-1',
+        polyline: 'encodedPolylineString',
+      })
+    })
+
+    it('デフォルトでは徒歩モードを使用する', async () => {
+      const mockResult = {
+        routes: [
+          {
+            legs: [
+              {
+                distance: { value: 1200 },
+                duration: { value: 900 },
+                start_address: '出発地',
+                end_address: '目的地',
+              },
+            ],
+            overview_polyline: '',
+          },
+        ],
+      }
+
+      mockService.route.mockImplementation((request, callback) => {
+        expect(request.travelMode).toBe('WALKING')
+        callback(mockResult, 'OK')
+      })
+
+      await getDirections(
+        { lat: 35.6586, lng: 139.7454 },
+        { lat: 35.6585, lng: 139.7471 }
+      )
+
+      expect(mockService.route).toHaveBeenCalled()
+    })
+
+    it('移動手段を指定できる', async () => {
+      const mockResult = {
+        routes: [
+          {
+            legs: [
+              {
+                distance: { value: 5000 },
+                duration: { value: 600 },
+                start_address: '出発地',
+                end_address: '目的地',
+              },
+            ],
+            overview_polyline: '',
+          },
+        ],
+      }
+
+      mockService.route.mockImplementation((request, callback) => {
+        callback(mockResult, 'OK')
+      })
+
+      const google = await initGoogleMaps()
+      await getDirections(
+        { lat: 35.6586, lng: 139.7454 },
+        { lat: 35.6585, lng: 139.7471 },
+        google.maps.TravelMode.DRIVING
+      )
+
+      expect(mockService.route).toHaveBeenCalledWith(
+        expect.objectContaining({
+          travelMode: 'DRIVING',
+        }),
+        expect.any(Function)
+      )
+    })
+
+    it('ルートが見つからない場合はnullを返す', async () => {
+      mockService.route.mockImplementation((request, callback) => {
+        callback(null, 'NOT_FOUND')
+      })
+
+      const result = await getDirections(
+        { lat: 35.6586, lng: 139.7454 },
+        { lat: 35.6585, lng: 139.7471 }
+      )
+
+      expect(result).toBeNull()
+    })
+
+    it('APIエラー時はnullを返す', async () => {
+      mockService.route.mockImplementation((request, callback) => {
+        callback(null, 'ERROR')
+      })
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+
+      const result = await getDirections(
+        { lat: 35.6586, lng: 139.7454 },
+        { lat: 35.6585, lng: 139.7471 }
+      )
+
+      expect(result).toBeNull()
+      expect(consoleSpy).toHaveBeenCalled()
+
+      consoleSpy.mockRestore()
+    })
+
+    it('日本語と日本地域を指定してAPIを呼び出す', async () => {
+      const mockResult = {
+        routes: [
+          {
+            legs: [
+              {
+                distance: { value: 1000 },
+                duration: { value: 600 },
+                start_address: '出発地',
+                end_address: '目的地',
+              },
+            ],
+            overview_polyline: '',
+          },
+        ],
+      }
+
+      mockService.route.mockImplementation((request, callback) => {
+        callback(mockResult, 'OK')
+      })
+
+      await getDirections(
+        { lat: 35.6586, lng: 139.7454 },
+        { lat: 35.6585, lng: 139.7471 }
+      )
+
+      expect(mockService.route).toHaveBeenCalledWith(
+        expect.objectContaining({
+          language: 'ja',
+          region: 'jp',
+        }),
+        expect.any(Function)
+      )
+    })
+  })
+
+  describe('getMultipleRoutes', () => {
+    it('複数地点の経路を順番に取得できる', async () => {
+      const mockResult1 = {
+        routes: [
+          {
+            legs: [
+              {
+                distance: { value: 1000 },
+                duration: { value: 600 },
+                start_address: '地点1',
+                end_address: '地点2',
+              },
+            ],
+            overview_polyline: 'poly1',
+          },
+        ],
+      }
+
+      const mockResult2 = {
+        routes: [
+          {
+            legs: [
+              {
+                distance: { value: 1500 },
+                duration: { value: 900 },
+                start_address: '地点2',
+                end_address: '地点3',
+              },
+            ],
+            overview_polyline: 'poly2',
+          },
+        ],
+      }
+
+      let callCount = 0
+      mockService.route.mockImplementation((request, callback) => {
+        callCount++
+        if (callCount === 1) {
+          callback(mockResult1, 'OK')
+        } else {
+          callback(mockResult2, 'OK')
+        }
+      })
+
+      const locations = [
+        { lat: 35.6586, lng: 139.7454 }, // 地点1
+        { lat: 35.6585, lng: 139.7471 }, // 地点2
+        { lat: 35.6812, lng: 139.7671 }, // 地点3
+      ]
+
+      const routes = await getMultipleRoutes(locations)
+
+      expect(routes).toHaveLength(2)
+      expect(routes[0]).toEqual({
+        distance: 1000,
+        duration: 600,
+        startAddress: '地点1',
+        endAddress: '地点2',
+        polyline: 'poly1',
+      })
+      expect(routes[1]).toEqual({
+        distance: 1500,
+        duration: 900,
+        startAddress: '地点2',
+        endAddress: '地点3',
+        polyline: 'poly2',
+      })
+      expect(mockService.route).toHaveBeenCalledTimes(2)
+    })
+
+    it('1つの地点のみの場合は空配列を返す', async () => {
+      const locations = [{ lat: 35.6586, lng: 139.7454 }]
+
+      const routes = await getMultipleRoutes(locations)
+
+      expect(routes).toEqual([])
+      expect(mockService.route).not.toHaveBeenCalled()
+    })
+
+    it('一部のルートが見つからない場合はスキップする', async () => {
+      let callCount = 0
+      mockService.route.mockImplementation((request, callback) => {
+        callCount++
+        if (callCount === 1) {
+          // 1つ目のルートは成功
+          callback(
+            {
+              routes: [
+                {
+                  legs: [
+                    {
+                      distance: { value: 1000 },
+                      duration: { value: 600 },
+                      start_address: '地点1',
+                      end_address: '地点2',
+                    },
+                  ],
+                  overview_polyline: 'poly1',
+                },
+              ],
+            },
+            'OK'
+          )
+        } else {
+          // 2つ目のルートは見つからない
+          callback(null, 'NOT_FOUND')
+        }
+      })
+
+      const locations = [
+        { lat: 35.6586, lng: 139.7454 },
+        { lat: 35.6585, lng: 139.7471 },
+        { lat: 35.6812, lng: 139.7671 },
+      ]
+
+      const routes = await getMultipleRoutes(locations)
+
+      expect(routes).toHaveLength(1)
+      expect(mockService.route).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('calculateTotalDuration', () => {
+    it('ルート配列の合計移動時間を計算できる', () => {
+      const routes = [
+        {
+          distance: 1000,
+          duration: 600,
+          startAddress: '地点1',
+          endAddress: '地点2',
+          polyline: 'poly1',
+        },
+        {
+          distance: 1500,
+          duration: 900,
+          startAddress: '地点2',
+          endAddress: '地点3',
+          polyline: 'poly2',
+        },
+        {
+          distance: 800,
+          duration: 480,
+          startAddress: '地点3',
+          endAddress: '地点4',
+          polyline: 'poly3',
+        },
+      ]
+
+      const total = calculateTotalDuration(routes)
+
+      expect(total).toBe(1980) // 600 + 900 + 480
+    })
+
+    it('空配列の場合は0を返す', () => {
+      const total = calculateTotalDuration([])
+
+      expect(total).toBe(0)
+    })
+  })
+
+  describe('formatDuration', () => {
+    it('秒を「◯時間◯分」形式に変換できる（時間あり）', () => {
+      const formatted = formatDuration(7380) // 2時間3分
+
+      expect(formatted).toBe('2時間3分')
+    })
+
+    it('秒を「◯分」形式に変換できる（時間なし）', () => {
+      const formatted = formatDuration(900) // 15分
+
+      expect(formatted).toBe('15分')
+    })
+
+    it('1時間ちょうどの場合', () => {
+      const formatted = formatDuration(3600)
+
+      expect(formatted).toBe('1時間0分')
+    })
+
+    it('0秒の場合', () => {
+      const formatted = formatDuration(0)
+
+      expect(formatted).toBe('0分')
+    })
+
+    it('30秒などの端数は切り捨てる', () => {
+      const formatted = formatDuration(690) // 11分30秒
+
+      expect(formatted).toBe('11分')
+    })
+
+    it('3時間45分のような長時間も正しく表示', () => {
+      const formatted = formatDuration(13500) // 3時間45分
+
+      expect(formatted).toBe('3時間45分')
+    })
+  })
+})

--- a/__tests__/lib/maps/loader.test.ts
+++ b/__tests__/lib/maps/loader.test.ts
@@ -62,6 +62,7 @@ describe('lib/maps/loader', () => {
       expect(importLibrary).toHaveBeenCalledWith('places')
       expect(importLibrary).toHaveBeenCalledWith('geometry')
       expect(importLibrary).toHaveBeenCalledWith('marker')
+      expect(importLibrary).toHaveBeenCalledWith('routes')
     })
 
     it('複数回呼び出しても同じPromiseを返す（重複読み込み防止）', async () => {
@@ -84,8 +85,8 @@ describe('lib/maps/loader', () => {
       const { setOptions, importLibrary } = require('@googlemaps/js-api-loader')
       // setOptionsは1回のみ呼ばれる（重複読み込み防止）
       expect(setOptions).toHaveBeenCalledTimes(1)
-      // importLibraryは4つのライブラリ（maps, places, geometry, marker）で各1回のみ
-      expect(importLibrary).toHaveBeenCalledTimes(4)
+      // importLibraryは5つのライブラリ（maps, places, geometry, marker, routes）で各1回のみ
+      expect(importLibrary).toHaveBeenCalledTimes(5)
     })
 
     it('APIキーが未設定の場合はエラーを投げる', () => {

--- a/lib/maps/README.md
+++ b/lib/maps/README.md
@@ -10,7 +10,7 @@ maps/
 ├── constants.ts        # 定数定義（ズームレベル等）（✅実装済み）
 ├── utils.ts            # 座標計算などのユーティリティ（✅実装済み）
 ├── places.ts           # Places API ラッパー（✅実装済み - issue#36）
-└── directions.ts       # Directions API ラッパー（実装予定）
+└── directions.ts       # Directions API ラッパー（✅実装済み - issue#43）
 ```
 
 ## 実装済み機能
@@ -37,6 +37,14 @@ maps/
 - `searchPlacesByArea()` - エリア名から観光スポットを検索
 - `getPlaceDetails()` - Google Places IDからスポット詳細を取得
 - `PlaceResult`型 - Places API検索結果の型定義
+
+### directions.ts（✅ issue#43で実装）
+
+- `getDirections()` - 2地点間のルート情報を取得
+- `getMultipleRoutes()` - 複数地点の経路を一括取得
+- `calculateTotalDuration()` - 移動時間の合計を計算
+- `formatDuration()` - 秒を「◯時間◯分」形式に変換
+- `RouteInfo`型 - ルート情報の型定義
 
 ## 使用例
 
@@ -94,6 +102,35 @@ const spots = await searchPlacesByArea('東京都')
 fitBounds(map, spots)
 ```
 
-## 実装予定
+### 2地点間の移動時間を取得
 
-- フェーズ5: Directions API（ルート検索・最適化）
+```typescript
+import { getDirections, formatDuration } from '@/lib/maps/directions'
+
+const route = await getDirections(
+  { lat: 35.6586, lng: 139.7454 }, // 東京タワー
+  { lat: 35.6585, lng: 139.7471 } // 増上寺
+)
+
+if (route) {
+  console.log(`距離: ${(route.distance / 1000).toFixed(1)}km`)
+  console.log(`所要時間: ${formatDuration(route.duration)}`)
+}
+```
+
+### 複数スポット間の移動時間を計算
+
+```typescript
+import { getMultipleRoutes, calculateTotalDuration, formatDuration } from '@/lib/maps/directions'
+
+const locations = [
+  { lat: 35.6812, lng: 139.7671 }, // 東京駅
+  { lat: 35.6586, lng: 139.7454 }, // 東京タワー
+  { lat: 35.7101, lng: 139.8107 }, // スカイツリー
+]
+
+const routes = await getMultipleRoutes(locations)
+const total = calculateTotalDuration(routes)
+
+console.log(`全${routes.length}区間の合計移動時間: ${formatDuration(total)}`)
+```

--- a/lib/maps/directions.ts
+++ b/lib/maps/directions.ts
@@ -1,0 +1,162 @@
+/**
+ * Google Directions API ラッパー
+ * スポット間の移動時間とルート情報を取得
+ */
+
+import { initGoogleMaps } from './loader'
+
+/**
+ * Directions APIから取得したルート情報
+ */
+export interface RouteInfo {
+  /** 距離（メートル） */
+  distance: number
+  /** 所要時間（秒） */
+  duration: number
+  /** 出発地の住所 */
+  startAddress: string
+  /** 目的地の住所 */
+  endAddress: string
+  /** エンコードされたポリライン（地図上にルートを描画する際に使用） */
+  polyline?: string
+}
+
+/**
+ * 2地点間のルート情報を取得
+ *
+ * @param origin - 出発地の座標
+ * @param destination - 目的地の座標
+ * @param mode - 移動手段（デフォルト: 徒歩）
+ * @returns ルート情報（ルートが見つからない場合はnull）
+ *
+ * @example
+ * ```typescript
+ * const route = await getDirections(
+ *   { lat: 35.6586, lng: 139.7454 }, // 東京タワー
+ *   { lat: 35.6585, lng: 139.7471 }, // 増上寺
+ *   google.maps.TravelMode.WALKING
+ * )
+ *
+ * if (route) {
+ *   console.log(`距離: ${route.distance}m`)
+ *   console.log(`所要時間: ${formatDuration(route.duration)}`)
+ * }
+ * ```
+ */
+export async function getDirections(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number },
+  mode?: google.maps.TravelMode
+): Promise<RouteInfo | null> {
+  const google = await initGoogleMaps()
+  const service = new google.maps.DirectionsService()
+
+  // デフォルトは徒歩モード
+  const travelMode = mode ?? google.maps.TravelMode.WALKING
+
+  return new Promise((resolve) => {
+    service.route(
+      {
+        origin: new google.maps.LatLng(origin.lat, origin.lng),
+        destination: new google.maps.LatLng(destination.lat, destination.lng),
+        travelMode: travelMode,
+        language: 'ja',
+        region: 'jp',
+      },
+      (result, status) => {
+        if (status === google.maps.DirectionsStatus.OK && result) {
+          const route = result.routes[0]
+          const leg = route.legs[0]
+
+          resolve({
+            distance: leg.distance?.value || 0,
+            duration: leg.duration?.value || 0,
+            startAddress: leg.start_address || '',
+            endAddress: leg.end_address || '',
+            polyline: route.overview_polyline || '',
+          })
+        } else {
+          console.error(`[getDirections] Directions request failed: ${status}`)
+          resolve(null)
+        }
+      }
+    )
+  })
+}
+
+/**
+ * 複数地点の経路を一括取得
+ * スポットの配列を順番に巡るルートを取得する
+ *
+ * @param locations - スポット座標の配列
+ * @param mode - 移動手段（デフォルト: 徒歩）
+ * @returns スポット間のルート情報配列（ルートが見つからない区間はスキップ）
+ *
+ * @example
+ * ```typescript
+ * const locations = [
+ *   { lat: 35.6812, lng: 139.7671 }, // 東京駅
+ *   { lat: 35.6586, lng: 139.7454 }, // 東京タワー
+ *   { lat: 35.7101, lng: 139.8107 }, // スカイツリー
+ * ]
+ *
+ * const routes = await getMultipleRoutes(locations)
+ * console.log(`全${routes.length}区間のルートを取得`)
+ * ```
+ */
+export async function getMultipleRoutes(
+  locations: Array<{ lat: number; lng: number }>,
+  mode?: google.maps.TravelMode
+): Promise<RouteInfo[]> {
+  const routes: RouteInfo[] = []
+
+  for (let i = 0; i < locations.length - 1; i++) {
+    const route = await getDirections(locations[i], locations[i + 1], mode)
+    if (route) {
+      routes.push(route)
+    }
+  }
+
+  return routes
+}
+
+/**
+ * 移動時間の合計を計算
+ *
+ * @param routes - ルート情報配列
+ * @returns 合計移動時間（秒）
+ *
+ * @example
+ * ```typescript
+ * const routes = await getMultipleRoutes(locations)
+ * const total = calculateTotalDuration(routes)
+ * console.log(`合計移動時間: ${formatDuration(total)}`)
+ * ```
+ */
+export function calculateTotalDuration(routes: RouteInfo[]): number {
+  return routes.reduce((total, route) => total + route.duration, 0)
+}
+
+/**
+ * 秒を「◯時間◯分」形式に変換
+ *
+ * @param seconds - 秒数
+ * @returns フォーマット済み文字列
+ *
+ * @example
+ * ```typescript
+ * formatDuration(900)   // "15分"
+ * formatDuration(3600)  // "1時間0分"
+ * formatDuration(7380)  // "2時間3分"
+ * ```
+ */
+export function formatDuration(seconds: number): string {
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+
+  if (hours > 0) {
+    return `${hours}時間${minutes}分`
+  } else {
+    return `${minutes}分`
+  }
+}

--- a/lib/maps/loader.ts
+++ b/lib/maps/loader.ts
@@ -54,6 +54,7 @@ export function initGoogleMaps(): Promise<typeof google> {
     importLibrary('places'),
     importLibrary('geometry'),
     importLibrary('marker'), // Advanced Markers API
+    importLibrary('routes'), // Directions API
   ]).then(() => {
     // グローバルのgoogleオブジェクトを返す
     return google


### PR DESCRIPTION
## 📝 概要

Google Directions APIのラッパーを実装し、スポット間の移動時間とルート情報を取得できるようにしました。

## 🎯 実装内容

### 新規ファイル
- `lib/maps/directions.ts`: Directions APIラッパー本体
  - `getDirections()`: 2地点間のルート情報取得（デフォルト: 徒歩モード）
  - `getMultipleRoutes()`: 複数地点の経路を一括取得
  - `calculateTotalDuration()`: 合計移動時間の計算
  - `formatDuration()`: 秒を「◯時間◯分」形式に変換
  - `RouteInfo`型: ルート情報の型定義（distance, duration, startAddress, endAddress, polyline）

### 更新ファイル
- `lib/maps/loader.ts`: `routes`ライブラリを追加してDirections APIを有効化
- `__tests__/lib/maps/directions.test.ts`: 17個のテストケースを実装
- `__tests__/lib/maps/loader.test.ts`: `routes`ライブラリのロードをテスト
- `lib/maps/README.md`: 実装済み機能として記載、使用例を追加

## ✅ テスト計画

### ユニットテスト（17/17 パス）
- ✅ 2地点間のルート取得
- ✅ デフォルト徒歩モードの確認
- ✅ 移動手段の指定
- ✅ ルート未発見時のエラーハンドリング
- ✅ APIエラー時のエラーハンドリング
- ✅ 日本語・日本地域の指定確認
- ✅ 複数地点の経路一括取得
- ✅ 1地点のみの場合の処理
- ✅ 一部ルート未発見時のスキップ処理
- ✅ 合計移動時間の計算
- ✅ 時間フォーマット（時間あり/なし、端数処理）

### 品質チェック
- ✅ 型チェック: エラーなし
- ✅ ESLint: エラーなし（既存の警告のみ）
- ✅ ビルド: 成功
- ✅ 全テストスイート: パス

## 🔍 主な技術的決定

### 1. デフォルト引数の扱い
\`google.maps.TravelMode\`をデフォルト引数として使用すると、モジュール読み込み時に評価されるためテスト環境でエラーになります。そのため、オプショナル引数にして関数内で条件分岐する設計にしました。

```typescript
// ❌ これだとテスト時にエラー
function getDirections(mode: google.maps.TravelMode = google.maps.TravelMode.WALKING)

// ✅ 正しい実装
function getDirections(mode?: google.maps.TravelMode) {
  const travelMode = mode ?? google.maps.TravelMode.WALKING
}
```

### 2. エラーハンドリング
ルートが見つからない場合（離島など）は\`null\`を返す設計にし、呼び出し側でフォールバック処理（直線距離での推定など）を実装しやすくしました。

### 3. TDD採用
テストを先に書くことで、エラーハンドリングやエッジケースを漏れなく実装できました。

## 📚 使用例

```typescript
// 2地点間の移動時間取得
const route = await getDirections(
  { lat: 35.6586, lng: 139.7454 }, // 東京タワー
  { lat: 35.6585, lng: 139.7471 }  // 増上寺
)

if (route) {
  console.log(\`距離: \${(route.distance / 1000).toFixed(1)}km\`)
  console.log(\`所要時間: \${formatDuration(route.duration)}\`)
}

// 複数スポット間の移動時間計算
const locations = [
  { lat: 35.6812, lng: 139.7671 }, // 東京駅
  { lat: 35.6586, lng: 139.7454 }, // 東京タワー
  { lat: 35.7101, lng: 139.8107 }, // スカイツリー
]

const routes = await getMultipleRoutes(locations)
const total = calculateTotalDuration(routes)
console.log(\`合計移動時間: \${formatDuration(total)}\`)
```

## 🔗 関連Issue

Closes #43

## 📅 次のステップ

このDirections APIを活用して、issue#44「時刻計算ロジック」で各スポットの訪問時刻を自動計算する機能を実装予定です。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)